### PR TITLE
Remove unnecessary flex layout in MetricOverview

### DIFF
--- a/src/components/views/css/MetricOverview.css
+++ b/src/components/views/css/MetricOverview.css
@@ -1,9 +1,4 @@
 .metric-overview {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    justify-content: space-between;
     margin: 50px 0;
 }
 


### PR DESCRIPTION
This doesn't appear to have any effect in modern browsers any more, even
at mobile resolution, and it causes issues on IE11.