### PR TITLE
Fix #124: Add IE 11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "size": "source-map-explorer build/static/js/main.*"
     },
     "dependencies": {
-        "core-js": "2.5.7",
+        "babel-polyfill": "6.26.0",
         "d3-scale": "2.0.0",
         "d3-selection": "1.3.0",
         "d3-shape": "1.2.0",

--- a/src/components/views/Application.js
+++ b/src/components/views/Application.js
@@ -5,6 +5,7 @@ import Main from './Main';
 import Footer from './Footer';
 
 import './css/Application.css';
+import './css/BrowserHacks.css';
 
 
 export default () => (

--- a/src/components/views/Footer.js
+++ b/src/components/views/Footer.js
@@ -5,7 +5,13 @@ import './css/Footer.css';
 
 export default class extends React.Component {
     componentDidMount() {
-        document.querySelectorAll('footer a').forEach(anchor => {
+        let links = document.querySelectorAll('footer a');
+
+        // IE doesn't support NodeList.forEach, so we need to convert links to
+        // an array first.
+        links = Array.from(links);
+
+        links.forEach(anchor => {
             anchor.target = '_blank';
             anchor.rel = 'noopener noreferrer';
         });

--- a/src/components/views/css/BrowserHacks.css
+++ b/src/components/views/css/BrowserHacks.css
@@ -1,0 +1,27 @@
+/* Target IE 10+
+   https://philipnewcomer.net/2014/04/target-internet-explorer-10-11-css/ */
+@media all and (-ms-high-contrast: none), all and (-ms-high-contrast: active) {
+    /* IE doesn't recognize the main element, so it treats it as inline by
+       default. */
+    main {
+        display: block;
+    }
+
+    /* For some reason, IE shows a horizontal scrollbar on the whole page when
+       this rule isn't present. There isn't great documentation about this
+       problem, but it may have something to do with this:
+
+       https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7226597/ */
+    .metricsGraphicsCon svg {
+        overflow: hidden;
+    }
+
+    /* Fix issue where the contents of .metrics-overview overflow it in IE. It
+       appears to be this bug, although the suggested solution doesn't work for
+       some reason.
+
+       https://github.com/philipwalton/flexbugs#flexbug-2 */
+    #dashboard .metric-overview {
+        display: block;
+    }
+}

--- a/src/lib/polyfills.js
+++ b/src/lib/polyfills.js
@@ -1,10 +1,6 @@
-// Internet Explorer 11 has no support for these...
-import 'core-js/fn/array/find';
-import 'core-js/fn/array/includes';
-import 'core-js/fn/object/assign';
-import 'core-js/es6/promise';
-import 'whatwg-fetch';
-
-// Internet Explorer 11 has incomplete support for these...
-import 'core-js/es6/map';
-import 'core-js/es6/set';
+// Provide polyfills for use in older browsers.
+//
+// babel-polyfill is big, but importing modules as-needed from core-js is a game
+// of whack-a-mole. We did use core-js in the past, but even after importing
+// many individual modules we were left unsure that we had covered everything.
+import 'babel-polyfill';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,6 +1064,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-env@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
@@ -1998,10 +2006,6 @@ cookie@0.3.1:
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-
-core-js@2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -7706,6 +7710,10 @@ reduce-function-call@^1.0.1:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Lets get #161 in first. But this is ready.

To test, install an [IE 11 VM](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) and point IE at http://10.0.2.2:3000.