### PR TITLE
Fix #156: Don't scroll upon region change

### DIFF
--- a/src/components/views/MetricOverview.js
+++ b/src/components/views/MetricOverview.js
@@ -7,73 +7,104 @@ import StripedHeader from './StripedHeader';
 import './css/MetricOverview.css';
 
 
-export default props => {
-    // Create a markdown parser that only parses links
-    const markdownParser = markdownIt('zero').enable('link');
+class MetricOverview extends React.Component {
+    // Create a markdown parser that only parses links. It needs to be static
+    // for static methods to use it.
+    static markdownParser = markdownIt('zero').enable('link');
 
-    let maybeMetricDescription = null;
-    if (props.description) {
-        const multipleParagraphs = Array.isArray(props.description);
-        if (multipleParagraphs) {
-            maybeMetricDescription = (
-                <div className="metric-description">
-                    {props.description.map((paragraph, index) => (
-                        <p key={index} dangerouslySetInnerHTML={
-                            {__html: markdownParser.renderInline(paragraph)}
-                        } />
-                    ))}
-                </div>
-            );
-        } else {
-            maybeMetricDescription = (
-                <p className="metric-description" dangerouslySetInnerHTML={
-                    {__html: markdownParser.renderInline(props.description)}
-                } />
-            );
+    constructor(props) {
+        super(props);
+
+        // Lazy-load the proper components
+        if (props.type === 'line') {
+            this.ChartContainer = lazyLoad(import('../containers/ChartContainer'));
+        } else if (props.type === 'table') {
+            this.CustomizableDateContainer = lazyLoad(import('../containers/CustomizableDateContainer'));
+            this.DataTableContainer = lazyLoad(import('../containers/DataTableContainer'));
         }
+
+        this.state = { maybeMetricDescription: null };
     }
 
-    let MetricContainer = null;
-    if (props.type === 'line') {
-        const ChartContainer = lazyLoad(import('../containers/ChartContainer'));
-        const numPopulations = Object.keys(props.data[props.activeCategory].populations).length;
-        MetricContainer = (
-            <ChartContainer
-                legendTarget={`#${props.identifier} .legend`}
-                title={props.title}
-                data={props.data}
-                activeCategory={props.activeCategory}
-                axes={props.axes || {}}
-                annotations={props.annotations || {}}
-                numPopulations={numPopulations}
-            />
-        );
-    } else if (props.type === 'table') {
-        const CustomizableDateContainer = lazyLoad(import('../containers/CustomizableDateContainer'));
-        const DataTableContainer = lazyLoad(import('../containers/DataTableContainer'));
+    static getDerivedStateFromProps(props, state) {
+        const newState = {};
 
-        // We're omitting titleComponent here since the title is set in a previous sibling.
-        MetricContainer = (
-            <CustomizableDateContainer
-                dates={Object.keys(props.data[props.activeCategory].dates)}
-                metric={true}>
-                <DataTableContainer
+        // Only build the description component if props.description is non-null
+        // and the description component hasn't been built yet.
+        //
+        // Only re-build the description component if props.description is
+        // non-null and has changed.
+        if (props.description && (!state.description || props.description !== state.description)) {
+            newState.description = props.description;
+
+            const multipleParagraphs = Array.isArray(props.description);
+
+            if (multipleParagraphs) {
+                newState.maybeMetricDescription = (
+                    <div className="metric-description">
+                        {props.description.map((paragraph, index) => (
+                            <p key={index} dangerouslySetInnerHTML={
+                                {__html: MetricOverview.markdownParser.renderInline(paragraph)}
+                            } />
+                        ))}
+                    </div>
+                );
+            } else {
+                newState.maybeMetricDescription = (
+                    <p className="metric-description" dangerouslySetInnerHTML={
+                        {__html: MetricOverview.markdownParser.renderInline(props.description)}
+                    } />
+                );
+            }
+        }
+
+        if (Object.keys(newState).length > 0) return newState;
+        return null;
+    }
+
+    render() {
+        const props = this.props;
+
+        let MetricContainer = null;
+        if (props.type === 'line') {
+            const numPopulations = Object.keys(props.data[props.activeCategory].populations).length;
+            MetricContainer = (
+                <this.ChartContainer
+                    legendTarget={`#${props.identifier} .legend`}
+                    title={props.title}
                     data={props.data}
                     activeCategory={props.activeCategory}
-                    columns={props.columns || {}}
+                    axes={props.axes || {}}
+                    annotations={props.annotations || {}}
+                    numPopulations={numPopulations}
                 />
-            </CustomizableDateContainer>
+            );
+        } else if (props.type === 'table') {
+            // We're omitting titleComponent here since the title is set in a previous sibling.
+            MetricContainer = (
+                <this.CustomizableDateContainer
+                    dates={Object.keys(props.data[props.activeCategory].dates)}
+                    metric={true}>
+                    <this.DataTableContainer
+                        data={props.data}
+                        activeCategory={props.activeCategory}
+                        columns={props.columns || {}}
+                    />
+                </this.CustomizableDateContainer>
+            );
+        }
+
+        return (
+            <div id={props.identifier} className="metric-overview">
+                <StripedHeader tag="h5" label={props.title} />
+                {this.state.maybeMetricDescription}
+                <div className="metric-and-legend">
+                    {MetricContainer}
+                    <div className="legend" />
+                </div>
+            </div>
         );
     }
+}
 
-    return (
-        <div id={props.identifier} className="metric-overview">
-            <StripedHeader tag="h5" label={props.title} />
-            {maybeMetricDescription}
-            <div className="metric-and-legend">
-                {MetricContainer}
-                <div className="legend" />
-            </div>
-        </div>
-    );
-};
+export default MetricOverview;


### PR DESCRIPTION
This commit ended up being a little more involved than expected. This
bug was happening because the MetricsGraphics component was re-loaded
every time the region selector changed. Fixing the bug meant only
loading the MetricsGraphics component once, which meant responding to
state changes a little more intelligently. So a lot of state-management
code was changed.

The good news is that I took the opportunity to improve performance a
bit. For example, chart descriptions are no longer re-rendered every
time chart data changes.