### PR TITLE
Fix #178: Update homepage

### DIFF
--- a/src/components/views/Home.js
+++ b/src/components/views/Home.js
@@ -19,56 +19,71 @@ export default () => (
                 The Firefox Public Data Report is a weekly public report on the
                 activity, behavior, and hardware configuration of Firefox users.
             </p>
-            <span className="contrasted">The purpose of this report is twofold:</span>
-            <dl className="explanations split">
-                <div>
-                    <dt><StripedHeader tag="h3" label="Empowerment" /></dt>
-                    <dd>
-                        We want to empower developers, journalists, and the overall
-                        public to better understand the state of the web and the
-                        direction of trends in web browsing.
-                    </dd>
-                </div>
-                <div>
-                    <dt><StripedHeader tag="h3" label="Transparency" /></dt>
-                    <dd>
-                        At Mozilla, we like to say that we are "Open by Design." We
-                        believe in an open web, so data and insights from the public
-                        should be made public, so the public can benefit.
-                    </dd>
-                </div>
-            </dl>
-            <span className="contrasted">The report is split into 3 sections:</span>
-            <dl className="explanations alt">
-                <div>
-                    <dt><Link to="/dashboard/user-activity">User Activity</Link></dt>
-                    <dd>Metrics for the the overall Firefox Desktop user population.</dd>
-                </div>
-                <div>
-                    <dt><Link to="/dashboard/usage-behavior">Usage Behavior</Link></dt>
-                    <dd>The ways in which Firefox Desktop is being used.</dd>
-                </div>
-                <div>
-                    <dt><Link to="/dashboard/hardware">Hardware Across the Web</Link></dt>
-                    <dd>The specs and configurations for the machines running Firefox Desktop.</dd>
-                </div>
-            </dl>
-            <p>
-                All data is from a representative 10% sample from our Release,
-                Beta, ESR, and Other channels for Firefox and the report runs
-                once per week. Each datapoint covers a week's worth of data
-                (unless stated otherwise). All data is anonymized and aggregated
-                to ensure user
-                privacy. Mozilla publishes additional information about
-                {' '}its <a href="https://www.mozilla.org/privacy/">privacy policy</a>,
-                {' '}its <a href="https://www.mozilla.org/privacy/principles">privacy principles</a>,
-                {' '}its <a href="https://wiki.mozilla.org/Firefox/Data_Collection">data collection process</a>,
-                {' '}and its thoughts on <a href="https://www.mozilla.org/privacy/firefox/">internet privacy</a> in general.
-            </p>
-            <p>
-                You can learn more about this report by reading our announcement on
-                the Mozilla blog.
-            </p>
+            <section>
+                <h2 className="contrasted">Purpose</h2>
+                <span>The purpose of this report is twofold:</span>
+                <dl className="explanations split">
+                    <div>
+                        <dt><StripedHeader tag="h3" label="Empowerment" /></dt>
+                        <dd>
+                            We want to empower developers, journalists, and the overall
+                            public to better understand the state of the web and the
+                            direction of trends in web browsing.
+                        </dd>
+                    </div>
+                    <div>
+                        <dt><StripedHeader tag="h3" label="Transparency" /></dt>
+                        <dd>
+                            At Mozilla, we like to say that we are "Open by Design." We
+                            believe in an open web, so data and insights from the public
+                            should be made public, so the public can benefit.
+                        </dd>
+                    </div>
+                </dl>
+            </section>
+            <section>
+                <h2 className="contrasted">Content</h2>
+                <span>
+                    The report is split into Desktop and Mobile sections, with
+                    subsections for each.
+                </span>
+                <h3>Desktop</h3>
+                <dl className="explanations alt">
+                    <div>
+                        <dt><Link to="/dashboard/user-activity">User Activity</Link></dt>
+                        <dd>Metrics for the the overall Firefox Desktop user population.</dd>
+                    </div>
+                    <div>
+                        <dt><Link to="/dashboard/usage-behavior">Usage Behavior</Link></dt>
+                        <dd>The ways in which Firefox Desktop is being used.</dd>
+                    </div>
+                    <div>
+                        <dt><Link to="/dashboard/hardware">Hardware Across the Web</Link></dt>
+                        <dd>The specs and configurations for the machines running Firefox Desktop.</dd>
+                    </div>
+                </dl>
+                <h3>Mobile</h3>
+                <p>Coming soon</p>
+            </section>
+            <section>
+                <h2 className="contrasted">Methodology</h2>
+                <p>
+                    All data is from a representative 10% sample from our Release,
+                    Beta, ESR, and Other channels for Firefox and the report runs
+                    once per week. Each datapoint covers a week's worth of data
+                    (unless stated otherwise). All data is anonymized and aggregated
+                    to ensure user
+                    privacy. Mozilla publishes additional information about
+                    {' '}its <a href="https://www.mozilla.org/privacy/">privacy policy</a>,
+                    {' '}its <a href="https://www.mozilla.org/privacy/principles">privacy principles</a>,
+                    {' '}its <a href="https://wiki.mozilla.org/Firefox/Data_Collection">data collection process</a>,
+                    {' '}and its thoughts on <a href="https://www.mozilla.org/privacy/firefox/">internet privacy</a> in general.
+                </p>
+                <p>
+                    You can learn more about this report by reading our announcement on
+                    the Mozilla blog.
+                </p>
+            </section>
         </article>
     </React.Fragment>
 );

--- a/src/components/views/css/Application.css
+++ b/src/components/views/css/Application.css
@@ -55,7 +55,7 @@ a:hover {
     border-bottom: 1px solid #0070ff;
 }
 
-p {
+p, span {
     font-size: 1rem;
     line-height: 28px;
     margin: 10px 0;
@@ -93,7 +93,7 @@ dd {
         width: 85vw;
     }
 
-    p {
+    p, span {
         font-size: 1.1rem;
     }
 

--- a/src/components/views/css/Home.css
+++ b/src/components/views/css/Home.css
@@ -1,9 +1,14 @@
+#introduction section {
+    margin: 20px 0;
+}
+
 .explanations {
     display: flex;
     flex-direction: column;
     font-size: 1rem;
     justify-content: space-between;
     line-height: 1.5;
+    margin: 0;
 }
 
 .explanations.alt dt {
@@ -17,10 +22,6 @@
 
 .explanations.alt dd {
     background-color: #efefef;
-}
-
-.explanations > div {
-    margin-bottom: 20px;
 }
 
 .highlighted {

--- a/src/components/views/css/StripedHeader.css
+++ b/src/components/views/css/StripedHeader.css
@@ -11,6 +11,8 @@
     display: inline-block;
     padding: 0 10px;
     position: relative;
+    line-height: inherit;
+    margin: 0;
 }
 
 .striped span::before {


### PR DESCRIPTION
This commit updates the homepage copy to clarify that a mobile section
of the report is coming soon. The rest of the changes are stylistic. I
didn't want to change the style of the homepage too dramatically, but
some amount of reshuffling was needed for the separate Desktop and
Mobile sections to make sense.