### PR TITLE
Move datasets endpoints to data.firefox.com

### DIFF
--- a/config/dashboards.json
+++ b/config/dashboards.json
@@ -7,17 +7,17 @@
                 {
                     "key": "user-activity",
                     "menuTitle": "User Activity",
-                    "source": "https://ensemble-transposer.herokuapp.com/datasets/user-activity"
+                    "source": "https://data.firefox.com/datasets/desktop/user-activity"
                 },
                 {
                     "key": "usage-behavior",
                     "menuTitle": "Usage Behavior",
-                    "source": "https://ensemble-transposer.herokuapp.com/datasets/usage-behavior"
+                    "source": "https://data.firefox.com/datasets/desktop/usage-behavior"
                 },
                 {
                     "key": "hardware",
                     "menuTitle": "Hardware",
-                    "source": "https://ensemble-transposer.herokuapp.com/datasets/hardware"
+                    "source": "https://data.firefox.com/datasets/desktop/hardware"
                 }
             ]
         },


### PR DESCRIPTION
These are synced hourly from transposer using a lambda function, updates to the dashboard list will require a redeploy of the lambda function.