### PR TITLE
Fix #141: Simplify missing data error message

### DIFF
--- a/src/components/containers/DashboardContainer.js
+++ b/src/components/containers/DashboardContainer.js
@@ -24,17 +24,15 @@ class DashboardContainer extends React.Component {
         if (dataFetch.pending) {
             return <Spinner />;
         } else if (dataFetch.rejected) {
-            const extraErrorComponentProps = {};
-
             if (dataFetch.reason && dataFetch.reason.message) {
-                extraErrorComponentProps.message = dataFetch.reason.message;
+                // eslint-disable-next-line no-console
+                console.error(dataFetch.reason.message);
             }
 
             return (
                 <ErrorComponent
                     id="dashboard-fetch-error"
                     title="Error fetching dashboard"
-                    {...extraErrorComponentProps}
                 />
             );
         } else if (dataFetch.fulfilled) {


### PR DESCRIPTION
Do not display a message about JSON.parse() to the user, but do show it
in the console. Unfortunately, because of the way ensemble and
ensemble-transposer are hosted, it's not possible to determine if an
error results from a dataset not existing.