### PR TITLE
Debug date display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ensemble",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "engines": {
         "node": ">=8"

--- a/src/components/views/Chart.jsx
+++ b/src/components/views/Chart.jsx
@@ -30,8 +30,10 @@ export default props => {
     if (appendableUnits.includes(props.yUnit)) {
         extraOptions.yax_units = props.yUnit;
         extraOptions.yax_units_append = true;
+        extraOptions.utc_time = true;
     } else {
         extraOptions.y_label = props.yUnit;
+        extraOptions.utc_time = true;
 
         // Work around this bug:
         // https://github.com/metricsgraphics/metrics-graphics/issues/838
@@ -146,7 +148,7 @@ export default props => {
                 height={props.height}
                 width={props.width}
 
-                x_mouseover={dp => dateformat(dp.x, 'mmmm d, yyyy') + ': '}
+                x_mouseover={dp => dateformat(dp.x, 'mmmm d, yyyy', true) + ': '}
                 y_mouseover={dp => prettifyNumber(dp.y) + yUnitString}
 
                 min_y={minYToShow}

--- a/src/components/views/Chart.jsx
+++ b/src/components/views/Chart.jsx
@@ -14,6 +14,9 @@ import './css/Metric.css';
 export default props => {
     const extraOptions = {};
 
+    // ensure that times are formatted using UTC
+    extraOptions.utc_time = true;
+
     // metrics-graphics will give each population up to this number a unique
     // color. (The 11th unique color is black.) If a chart has more populations
     // than this, all remaining populations will also be colored black.
@@ -30,10 +33,8 @@ export default props => {
     if (appendableUnits.includes(props.yUnit)) {
         extraOptions.yax_units = props.yUnit;
         extraOptions.yax_units_append = true;
-        extraOptions.utc_time = true;
     } else {
         extraOptions.y_label = props.yUnit;
-        extraOptions.utc_time = true;
 
         // Work around this bug:
         // https://github.com/metricsgraphics/metrics-graphics/issues/838


### PR DESCRIPTION
The current version of the site is incorrectly parsing dates based on the timezone of the server, even though dates are recorded in UTC. The result is that dates on the site are displayed as being one day earlier than they actually were.

This change fixes the mouseover and x-axis date displays so that they are parsed in UTC, making FPDR date reporting consistent with internal reporting.

The internal MAU dashboard shows `158,779,109` clients on April 28, 2025.

The current version of the site shows the same number of clients, but on April 27, 2025:
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/ce1fb339-5e3d-4ff0-bbe1-95898f028804" />

After this fix the date correctly shows April 28, 2025:
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/9114c47d-8559-41e6-8179-ed3041113a99" />
